### PR TITLE
Multiple updates and fixes to writeTag.py

### DIFF
--- a/writeTag.py
+++ b/writeTag.py
@@ -131,12 +131,12 @@ def getTagType():
 def writeTag(tagdump, keydump, tagtype):
     if tagtype == "Gen 4 FUID":
         # Load tag dump onto RFID tag
-        output = run_command([pm3Location / pm3Command, "-c", f"hf mf restore --force -f {tagdump.replace(" ", "\\ ")} -k {keydump.replace(" ", "\\ ")}"], pipe=False)
+        output = run_command([pm3Location / pm3Command, "-c", f"hf mf restore --force -f \"{tagdump}\" -k {keydump.replace(" ", "\\ ")}"], pipe=False)
         return
 
     if tagtype == "Gen 4 UFUID":
         # Load tag dump onto RFID tag, then immediately seal
-        output = run_command([pm3Location / pm3Command, "-c", f"hf mf cload -f {tagdump.replace(" ", "\\ ")}; hf 14a raw -a -k -b 7 40; hf 14a raw -k 43; hf 14a raw -k -c e100; hf 14a raw -c 85000000000000000000000000000008"], pipe=False)
+        output = run_command([pm3Location / pm3Command, "-c", f"hf mf cload -f \"{tagdump}\"; hf 14a raw -a -k -b 7 40; hf 14a raw -k 43; hf 14a raw -k -c e100; hf 14a raw -c 85000000000000000000000000000008"], pipe=False)
 
 
 if __name__ == "__main__":

--- a/writeTag.py
+++ b/writeTag.py
@@ -62,10 +62,6 @@ def main():
     print()
     print("Tag Dump file: "+tagdump)
     print("Tag Key file: "+keydump)
-    confirm = input("Are these the correct files (y/N)? ")
-    if confirm.lower() not in ["y", "yes"]:
-        print("Files not correct, exiting")
-        exit(0)
 
     if not os.path.isfile(tagdump):
         print("Tag dump file not found")

--- a/writeTag.py
+++ b/writeTag.py
@@ -8,6 +8,7 @@ import subprocess
 import os
 import re
 import sys
+import struct
 from pathlib import Path
 
 from lib import strip_color_codes, get_proxmark3_location, run_command, testCommands
@@ -34,13 +35,13 @@ def main():
     # Run setup
     setup()
 
-    serial = None
+    uid = None
 
     if len(sys.argv) > 1:
         # If the user included an argument, check if it is a directoy
         if os.path.isdir(sys.argv[1]):
-            serial = (os.path.basename(os.path.dirname(sys.argv[1])))
-            tagdump = os.path.abspath(sys.argv[1] + "hf-mf-" + serial + "-dump.bin")
+            uid = (os.path.basename(os.path.dirname(sys.argv[1])))
+            tagdump = os.path.abspath(sys.argv[1] + "hf-mf-" + uid + "-dump.bin")
         else:
             # If not a directory assume it's the path to the tracefile
             tagdump = os.path.abspath(sys.argv[1])
@@ -52,9 +53,9 @@ def main():
         # If the user included a second argument, assume it's the path to the key file
         keydump = os.path.abspath(sys.argv[2])
     else:
-        if serial is not None:
+        if uid is not None:
             # If setial is set, automatically set keydump
-            keydump = os.path.abspath(sys.argv[1] + "hf-mf-" + serial + "-key.bin")
+            keydump = os.path.abspath(sys.argv[1] + "hf-mf-" + uid + "-key.bin")
         else:
             #Get the keyname/filepath from user
             keydump = input("Enter the path to the tag's key dump you wish to write: ").replace("\\ ", " ")
@@ -100,7 +101,9 @@ def main():
     print("Writing tag data now...")
     try:
         if tagtype == "Gen 4 UFUID":
-            writeTag(tagdump, serial, tagtype)
+            with open(tagdump, "rb") as f:
+                uid = "".join([f"{byte:02X}" for byte in f.read(4)])
+            writeTag(tagdump, uid, tagtype)
         else:
             writeTag(tagdump, keydump, tagtype)
     except Exception as err:

--- a/writeTag.py
+++ b/writeTag.py
@@ -67,6 +67,14 @@ def main():
         print("Files not correct, exiting")
         exit(0)
 
+    if not os.path.isfile(tagdump):
+        print("Tag dump file not found")
+        exit(66)
+    if not os.path.isfile(keydump):
+        print("Tag key file not found")
+        exit(66)
+
+
     print()
     print("Start by placing your Proxmark3 device onto the tag you")
     print("wish to write to, then press Enter. I'll wait for you.")

--- a/writeTag.py
+++ b/writeTag.py
@@ -89,6 +89,8 @@ def getTagType():
 
     match = re.search(rf"\[=\] --- Magic Tag Information\n(\[=\] <n/a>\n|{cap_re}+)", output)
     if not match:
+        match = re.search(rf"\[=\] --- Magic Tag Information\n\n(\[=\] <n/a>\n|{cap_re}+)", output)
+    if not match:
         raise RuntimeError("Could not obtain magic tag information")
 
     if "[=] <n/a>" in match.group(1):

--- a/writeTag.py
+++ b/writeTag.py
@@ -34,9 +34,16 @@ def main():
     # Run setup
     setup()
 
+    serial = None
+
     if len(sys.argv) > 1:
-        # If the user included an argument, assume it's the path to the tracefile
-        tagdump = os.path.abspath(sys.argv[1])
+        # If the user included an argument, check if it is a directoy
+        if os.path.isdir(sys.argv[1]):
+            serial = (os.path.basename(os.path.dirname(sys.argv[1])))
+            tagdump = os.path.abspath(sys.argv[1] + "hf-mf-" + serial + "-dump.bin")
+        else:
+            # If not a directory assume it's the path to the tracefile
+            tagdump = os.path.abspath(sys.argv[1])
     else:
         #Get the tracename/filepath from user
         tagdump = input("Enter the path to the tag dump you wish to write: ").replace("\\ ", " ")
@@ -45,8 +52,20 @@ def main():
         # If the user included a second argument, assume it's the path to the key file
         keydump = os.path.abspath(sys.argv[2])
     else:
-        #Get the keyname/filepath from user
-        keydump = input("Enter the path to the tag's key dump you wish to write: ").replace("\\ ", " ")
+        if serial is not None:
+            # If setial is set, automatically set keydump
+            keydump = os.path.abspath(sys.argv[1] + "hf-mf-" + serial + "-key.bin")
+        else:
+            #Get the keyname/filepath from user
+            keydump = input("Enter the path to the tag's key dump you wish to write: ").replace("\\ ", " ")
+
+    print()
+    print("Tag Dump file: "+tagdump)
+    print("Tag Key file: "+keydump)
+    confirm = input("Are these the correct files (y/N)? ")
+    if confirm.lower() not in ["y", "yes"]:
+        print("Files not correct, exiting")
+        exit(0)
 
     print()
     print("Start by placing your Proxmark3 device onto the tag you")

--- a/writeTag.py
+++ b/writeTag.py
@@ -98,7 +98,14 @@ def main():
         exit(0)
 
     print("Writing tag data now...")
-    writeTag(tagdump, keydump, tagtype)
+    try:
+        if tagtype == "Gen 4 UFUID":
+            writeTag(tagdump, serial, tagtype)
+        else:
+            writeTag(tagdump, keydump, tagtype)
+    except Exception as err:
+        sys.stderr.write('ERROR: %sn \n' % str(err))
+        exit(1)
 
     print()
     print("Writing complete! Your tag should now register on the AMS.")
@@ -137,8 +144,42 @@ def writeTag(tagdump, keydump, tagtype):
         return
 
     if tagtype == "Gen 4 UFUID":
-        # Load tag dump onto RFID tag, then immediately seal
-        output = run_command([pm3Location / pm3Command, "-c", f"hf mf cload -f \"{tagdump}\"; hf 14a raw -a -k -b 7 40; hf 14a raw -k 43; hf 14a raw -k -c e100; hf 14a raw -c 85000000000000000000000000000008"], pipe=False)
+        # Load tag dump onto RFID tag
+        output = run_command([pm3Location / pm3Command, "-c", f"hf mf cload -f \"{tagdump}\";"], pipe=False)
+
+        # Verify UID is correct
+        output = run_command([pm3Location / pm3Command, "-c", f"hf mf info"])
+        match = re.search(rf"\[\+\]  UID: (.. .. .. ..)", output)
+        if not match:
+            raise RuntimeError("Tag UID read error")
+
+        print()
+        print("Tag UID is: " + match.group(1).replace(" ", ""))
+
+        if match.group(1).replace(" ", "") != keydump:
+            print("Tag UID should be: " + keydump)
+            print()
+            confirm = input("Tag UID is not correct. Try again (y/N)? ")
+            if confirm.lower() not in ["y", "yes"]:
+                print("Retry denied, exiting")
+                exit(0)
+            writeTag(tagdump, keydump, tagtype)
+
+        # Seal tag
+        print()
+        print("=========== WARNING! == WARNING! == WARNING! ===========")
+        print("This is your last chance to avoid LOCKING the tag.")
+        print("LOCKING is required to use tags with Bambu.")
+        print()
+        print("This process is IRREVERSIBLE.")
+        print("========================================================")
+        print()
+
+        confirm = input("Write lock tag (y/N)? ")
+        if confirm.lower() not in ["y", "yes"]:
+            print("Tag has not been locked, it is not usable with Bambu")
+            exit(0)
+        output = run_command([pm3Location / pm3Command, "-c", f"hf 14a raw -a -k -b 7 40; hf 14a raw -k 43; hf 14a raw -k -c e100; hf 14a raw -c 85000000000000000000000000000008"])
 
 
 if __name__ == "__main__":

--- a/writeTag.py
+++ b/writeTag.py
@@ -79,10 +79,9 @@ def main():
 
     try:
         tagtype = getTagType()
-        return 0
     except Exception as err:
         sys.stderr.write('ERROR: %sn \n' % str(err))
-        return 1
+        exit(1)
 
     print()
     print("=========== WARNING! == WARNING! == WARNING! ===========")
@@ -115,9 +114,7 @@ def getTagType():
 
     cap_re = r"(?:\[\+\] Magic capabilities\.\.\. ([()/\w\d ]+)\n)"
 
-    match = re.search(rf"\[=\] --- Magic Tag Information\n(\[=\] <n/a>\n|{cap_re}+)", output)
-    if not match:
-        match = re.search(rf"\[=\] --- Magic Tag Information\n\n(\[=\] <n/a>\n|{cap_re}+)", output)
+    match = re.search(rf"\[=\] --- Magic Tag Information\n+(\[=\] <n/a>\n|{cap_re}+)", output)
     if not match:
         raise RuntimeError("Could not obtain magic tag information")
 

--- a/writeTag.py
+++ b/writeTag.py
@@ -77,7 +77,12 @@ def main():
 
     input()
 
-    tagtype = getTagType()
+    try:
+        tagtype = getTagType()
+        return 0
+    except Exception as err:
+        sys.stderr.write('ERROR: %sn \n' % str(err))
+        return 1
 
     print()
     print("=========== WARNING! == WARNING! == WARNING! ===========")


### PR DESCRIPTION
I have added support for passing a directory as a single argument to use filenames in the naming convention of [queengooborg/Bambu-Lab-RFID-Library](https://github.com/queengooborg/Bambu-Lab-RFID-Library/)

Verify that dump and key are files

Added try ... except to make errors easier to read

For UFUID:
> Validate UID of tag before sealing.
> Give a final choice to make sure user wants the seal tag